### PR TITLE
Get/Count methods don't return NodeNotFound for missing nodes

### DIFF
--- a/yaml/config.go
+++ b/yaml/config.go
@@ -69,6 +69,13 @@ func (f *File) Get(spec string) (string, error) {
 		return "", err
 	}
 
+	if node == nil {
+		return "", &NodeNotFound{
+			Full: spec,
+			Spec: spec,
+		}
+	}
+
 	scalar, ok := node.(Scalar)
 	if !ok {
 		return "", &NodeTypeMismatch{
@@ -89,6 +96,13 @@ func (f *File) Count(spec string) (int, error) {
 	node, err := Child(f.Root, spec)
 	if err != nil {
 		return -1, err
+	}
+
+	if node == nil {
+		return -1, &NodeNotFound{
+			Full: spec,
+			Spec: spec,
+		}
 	}
 
 	lst, ok := node.(List)


### PR DESCRIPTION
If the spec given to the Get or Count methods refers to a node that doesn't exist, then a NodeTypeMismatch is returned.  However, it would be much more useful if the NodeNotFound error was returned.  Especially when trying to default config settings that haven't been explicitly set.
