### PR TITLE
parser should only split on colons followed by a space

### DIFF
--- a/yaml/parser.go
+++ b/yaml/parser.go
@@ -211,6 +211,11 @@ func getType(line []byte) (typ, split int) {
 			case ' ', '"':
 				typ = typScalar
 			case ':':
+				// only split on colons followed by a space
+				if i+1 < len(line) && line[i+1] != ' ' {
+					continue
+				}
+
 				typ = typMapping
 				split = i
 			default:


### PR DESCRIPTION
We are using a fork of your yaml parser and I ran into a problem with the following yaml snippet:

```
url: http://www.example.com
```

I noticed that your parser splits on the colon in the url `http://www.example.com`, leading to the following structure:

```
url:
    http: //www.example.com
```

Quoting [Wikipedia](http://en.wikipedia.org/wiki/YAML#Syntax): **YAML requires that colons** and commas used as list separators **be followed by a space** so that scalar values containing embedded punctuation (such as 5,280 or http://www.wikipedia.org) can generally be represented without needing to be enclosed in quotes.

I added a small fix to `getType` in `parser.go`: In case of a colon, we look at the following character and only split on the colon if we find a space after. It's not the most beautiful fix but it solved our issue and I thought I'd share.
