### PR TITLE
Support for empty lines in multi-line strings and rendering multi-line scalars.

### DIFF
--- a/yaml/parser.go
+++ b/yaml/parser.go
@@ -107,19 +107,18 @@ func parseNode(r lineReader, ind int, initial Node) (node Node) {
 				trimmed := bytes.TrimSpace(end)
 				if len(trimmed) == 1 && trimmed[0] == '|' {
 					text := ""
+					lastLine := -1
 
 					for {
 						l := r.Next(1)
 						if l == nil {
 							break
 						}
-
-						s := string(l.line)
-						s = strings.TrimSpace(s)
-						if len(s) == 0 {
-							break
+						if lastLine != -1 {
+							text += strings.Repeat("\n", l.lineno - lastLine)
 						}
-						text = text + "\n" + s
+						text += string(l.line)
+						lastLine = l.lineno
 					}
 
 					types = append(types, typScalar)

--- a/yaml/parser_test.go
+++ b/yaml/parser_test.go
@@ -2,7 +2,6 @@ package yaml
 
 import (
 	"bytes"
-	"strings"
 	"testing"
 )
 
@@ -204,16 +203,29 @@ func TestGetType(t *testing.T) {
 }
 
 func Test_MultiLineString(t *testing.T) {
-	buf := bytes.NewBufferString("a : |\n  a\n  b\n\nc : d")
+	y_value := "a: |\n  b\n  c\n  \n  d\ne: f\n"
+	a_value := "b\nc\n\nd"
+	e_value := "f"
+
+	buf := bytes.NewBufferString(y_value)
 	node, err := Parse(buf)
 	if err != nil {
 		t.Error(err)
 	} else {
 		m := node.(Map)
-		v := m["a"].(Scalar)
-		v2 := strings.TrimSpace(string(v))
-		if v2 != "a\nb" {
-			t.Errorf("multi line parsed wrong thing: %v", v)
+		parsed := string(m["a"].(Scalar))
+		if parsed != a_value {
+			t.Errorf("multi line parsed wrong thing:\nexpected: %q\ngot:      %q", a_value, parsed)
 		}
+		parsed = string(m["e"].(Scalar))
+		if parsed != e_value {
+			t.Errorf("multi line parsed wrong thing:\nexpected: %q\ngot:      %q", e_value, parsed)
+		}
+	}
+
+	node = Map{"a": Scalar(a_value), "e": Scalar(e_value)}
+	rendered := Render(node)
+	if rendered != y_value {
+		t.Errorf("multi line rendered wrong thing:\nexpected: %q\ngot:      %q", y_value, rendered)
 	}
 }

--- a/yaml/types.go
+++ b/yaml/types.go
@@ -44,7 +44,8 @@ func (node Map) write(out io.Writer, firstind, nextind int) {
 	for _, key := range scalarkeys {
 		value := node[key].(Scalar)
 		out.Write(indent[:ind])
-		fmt.Fprintf(out, "%-*s %s\n", width+1, key+":", string(value))
+		fmt.Fprintf(out, "%-*s ", width+1, key+":")
+		value.write(out, 0, 0)
 		ind = nextind
 	}
 	for _, key := range objectkeys {
@@ -94,7 +95,15 @@ type Scalar string
 func (node Scalar) String() string { return string(node) }
 
 func (node Scalar) write(out io.Writer, ind, _ int) {
-	fmt.Fprintf(out, "%s%s\n", strings.Repeat(" ", ind), string(node))
+	s := string(node)
+	if strings.Contains(s, "\n") {
+		fmt.Fprintf(out, "%s|\n", strings.Repeat(" ", ind))
+		for _, v := range strings.Split(s, "\n") {
+			fmt.Fprintf(out, "%s%s\n", strings.Repeat(" ", ind+2), v)
+		}
+	} else {
+		fmt.Fprintf(out, "%s%s\n", strings.Repeat(" ", ind), s)
+	}
 }
 
 // Render returns a string of the node as a YAML document.  Note that


### PR DESCRIPTION
This pull request adds support for empty lines in multi-line strings, allowed per YAML's literal strings spec. Also, it fixes rendering multi-line scalars. For example:

```
node := yaml.Map{"a": yaml.Scalar("b\n\nc"), "d": yaml.Scalar("e")}
config := yaml.Render(node)
```

is rendered as:

```
a: |
  b

  c
d: e
```

And parsing the string above will result in a node identical to the original. 

Please consider it with love.
