### PR TITLE
BUGFIX: Added NodeNotFound error for maps

### DIFF
--- a/yaml/config.go
+++ b/yaml/config.go
@@ -250,6 +250,12 @@ func Child(root Node, spec string) (Node, error) {
 			}
 
 			n, ok = m[tok[1:]]
+			if !ok {
+				return nil, &NodeNotFound{
+					Full: spec,
+					Spec: last + tok,
+				}
+			}
 			return recur(n, last+tok, remain)
 		}
 		panic("unreachable")


### PR DESCRIPTION
Now it is possible to tell the difference between missing and empty node's in a map.
