### PR TITLE
Return a NodeNotFound error when yaml.Child map keys don't exist.

### DIFF
--- a/yaml/config.go
+++ b/yaml/config.go
@@ -250,6 +250,12 @@ func Child(root Node, spec string) (Node, error) {
 			}
 
 			n, ok = m[tok[1:]]
+			if !ok {
+				return nil, &NodeNotFound{
+					Full: spec,
+					Spec: last + tok,
+				}
+			}
 			return recur(n, last+tok, remain)
 		}
 		panic("unreachable")


### PR DESCRIPTION
See (internal) Google CL 81616445.  I realized that last + tok was required for the Spec, not just last, but either way.  This also doesn't gofmt the file to drop the trailing space up in the comments, as that CL did.
