### PR TITLE
Ignore document separators "---"

### DIFF
--- a/yaml/parser.go
+++ b/yaml/parser.go
@@ -240,7 +240,7 @@ func getType(line []byte) (typ, split int) {
 	}
 
 	if line[0] == '-' {
-		if line[1] == '-' && line[2] == '-' {
+		if len(line) == 3 && line[1] == '-' && line[2] == '-' {
 			// Ignore document separators "---"
 			// http://yaml.org/spec/1.0/#syntax-stream-doc
 			return

--- a/yaml/parser.go
+++ b/yaml/parser.go
@@ -240,6 +240,11 @@ func getType(line []byte) (typ, split int) {
 	}
 
 	if line[0] == '-' {
+		if line[1] == '-' && line[2] == '-' {
+			// Ignore document separators "---"
+			// http://yaml.org/spec/1.0/#syntax-stream-doc
+			return
+		}
 		typ = typSequence
 		split = 1
 		return


### PR DESCRIPTION
I started to work around this in my user code, but then figured It might be useful for other users of this library. Maybe this approach is too naïve?