### PR TITLE
Add support for search-based indexing of sequences

### DIFF
--- a/yaml/config.go
+++ b/yaml/config.go
@@ -227,7 +227,29 @@ func Child(root Node, spec string) (Node, error) {
 			}
 
 			if tok[0] == '[' && tok[len(tok)-1] == ']' {
-				if num, err := strconv.Atoi(tok[1 : len(tok)-1]); err == nil {
+				kv := strings.Split(tok[1 : len(tok)-1], "=")
+				if len(kv) == 2 {
+					key := kv[0]
+					val := kv[1]
+					for _, r := range s {
+						mr, ok := r.(Map)
+						if !ok {
+							return nil, &NodeTypeMismatch{
+								Node:     n,
+								Expected: "yaml.Map",
+								Full:     spec,
+								Spec:     last,
+								Token:    tok,
+							}
+						}
+						_, ok = mr[key]
+						if ok {
+							if mr[key].(Scalar).String() == val {
+								return recur(r, last+tok, remain)
+							}
+						}
+					}
+				} else if num, err := strconv.Atoi(tok[1 : len(tok)-1]); err == nil {
 					if num >= 0 && num < len(s) {
 						return recur(s[num], last+tok, remain)
 					}

--- a/yaml/config_test.go
+++ b/yaml/config_test.go
@@ -59,6 +59,7 @@ var configGetTests = []struct {
 	{"config.admin[0].username", "god", ""},
 	{"config.admin[1].username", "lowly", ""},
 	{"config.admin[2].username", "", `yaml: .config.admin[2].username: ".config.admin[2]" not found`},
+	{ "config.admin[username=lowly].password", "f!r3m3", ""},
 }
 
 func TestGet(t *testing.T) {


### PR DESCRIPTION
Enable searching a sequence by `[<key>=<value>]` lookup as an alternative to
numeric indexing.  Sequence elements must be maps. 

E.g. in terms of `example/yget`

  $ ./yget config.admin[username=lowly].password
  config.admin[username=lowly].password = "f!r3m3"
