### PR TITLE
Remove surrounding quotes around scalar values

### DIFF
--- a/yaml/parser.go
+++ b/yaml/parser.go
@@ -98,7 +98,7 @@ func parseNode(r lineReader, ind int, initial Node) (node Node) {
 			switch vtyp {
 			case typScalar:
 				types = append(types, typScalar)
-				pieces = append(pieces, string(end))
+				pieces = append(pieces, maybeRemoveQuotes(string(end)))
 				return
 			case typMapping:
 				types = append(types, typMapping)
@@ -195,6 +195,17 @@ func parseNode(r lineReader, ind int, initial Node) (node Node) {
 		node = prev
 	}
 	return
+}
+
+func maybeRemoveQuotes(s string) string {
+	for _, c := range []uint8{'\'', '"'} {
+		if s[0] == c && s[len(s)-1] == c {
+			s = s[1 : len(s)-1]
+			break
+		}
+	}
+
+	return s
 }
 
 func getType(line []byte) (typ, split int) {

--- a/yaml/parser_test.go
+++ b/yaml/parser_test.go
@@ -3,6 +3,7 @@ package yaml
 import (
 	"bytes"
 	"testing"
+	"strconv"
 )
 
 var parseTests = []struct {
@@ -138,22 +139,32 @@ var parseTests = []struct {
 	},
 	{
 		Input:  `test: "localhost:8080"`,
-		Output: `test: "localhost:8080"` + "\n",
+		Output: `test: localhost:8080` + "\n",
+	},
+	{
+		Input:  "key1: \"val1\"\n",
+		Output: "key1: val1\n",
+	},
+	{
+		Input:  "key1: 'val1'\n",
+		Output: "key1: val1\n",
 	},
 }
 
 func TestParse(t *testing.T) {
 	for idx, test := range parseTests {
-		buf := bytes.NewBufferString(test.Input)
-		node, err := Parse(buf)
-		if err != nil {
-			t.Errorf("parse: %s", err)
-		}
-		if got, want := Render(node), test.Output; got != want {
-			t.Errorf("---%d---", idx)
-			t.Errorf("got: %q:\n%s", got, got)
-			t.Errorf("want: %q:\n%s", want, want)
-		}
+		t.Run(strconv.Itoa(idx), func(t *testing.T) {
+			buf := bytes.NewBufferString(test.Input)
+			node, err := Parse(buf)
+			if err != nil {
+				t.Errorf("parse: %s", err)
+			}
+			if got, want := Render(node), test.Output; got != want {
+				t.Errorf("---%d---", idx)
+				t.Errorf("got: %q:\n%s", got, got)
+				t.Errorf("want: %q:\n%s", want, want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
This commit makes parser treat single- and double-quoted scalars as non-quoted values. It is more consistent with how other yaml parsers behave.

Please note that this change breaks backward compatibility.